### PR TITLE
Add support for .NET 8

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -51,7 +51,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Install .NET MAUI
       run: |
         dotnet nuget locals all --clear

--- a/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
+++ b/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst</TargetFrameworks>
-		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;net7.0-android33.0;net7.0-ios;net7.0-maccatalyst;net8.0;net8.0-android34.0;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net7.0-windows10.0.19041.0;net8.0-windows10.0.19041.0</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>

--- a/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
+++ b/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
@@ -30,9 +30,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="OxyPlot.Core" Version="2.1.2" />
-	  <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
-	  <PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.6" />
+		<PackageReference Include="OxyPlot.Core" Version="2.1.2" />
+		<PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.6" />
+		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.6" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" $(TargetFramework.StartsWith('net8.0')) ">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This fixes #6.

For now I'm only adding .NET 8 targets to the library, but not yet updating the sample to .NET 8 (because VS4Mac does not handle that well yet).