### PR TITLE
Fix GHA build errors on Mac

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -43,7 +43,7 @@ jobs:
         path: ./Source/*/nuget/*.nupkg
 
   macBuild:
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
       with:
@@ -55,7 +55,7 @@ jobs:
     - name: Setup XCode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15'
+        xcode-version: latest-stable
     - name: Install .NET MAUI
       run: |
         dotnet nuget locals all --clear

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -61,6 +61,8 @@ jobs:
         dotnet nuget locals all --clear
         dotnet workload install maui --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
         dotnet workload install android ios maccatalyst tvos macos maui wasm-tools maui-maccatalyst --source https://aka.ms/dotnet6/nuget/index.json --source https://api.nuget.org/v3/index.json
+    - name: Install Android tools
+      run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platforms;android-34" "build-tools;34.0.0" "platform-tools"
     - name: Build library (with nuget package)
       run: dotnet build ./Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj /p:Configuration=Release /t:restore,build,pack /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false
     - name: Build sample
@@ -79,9 +81,7 @@ jobs:
     - name: Install workloads
       run: dotnet workload install android wasm-tools maui-android
     - name: Install Android tools
-      run: |
-        ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager \
-        --sdk_root=$ANDROID_SDK_ROOT "platform-tools"
+      run: ${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager --sdk_root=$ANDROID_SDK_ROOT "platform-tools"
     - name: Build library (with nuget package)
       run: dotnet build ./Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj /p:Configuration=Release /t:restore,build,pack /p:Version=$(git describe) /p:ContinuousIntegrationBuild=true /p:DeterministicSourcePaths=false
     - name: Build sample


### PR DESCRIPTION
This PR fixes recent GHA failures on MacOS:

```
error MT0180: This version of Microsoft.iOS requires the iOS 18.0 SDK (shipped with Xcode 16.0).
Either upgrade Xcode to get the required header files or set the managed linker behaviour to Link
Framework SDKs Only in your project's iOS Build Options > Linker Behavior (to try to avoid the new APIs).
```

This is due to the latest MAUI workloads in SDK 8.0.402 requiring XCode 16, see https://github.com/dotnet/maui/issues/24819. It is fixed by updating the Mac build host to MacOS 15 and XCode 16.

After that the build failed because the MacOS 15 image on GHA apparently misses the Android 34 SDK and tools:

```
Cannot find `aapt`. Please install the Android SDK Build-Tools package with the `/Users/runner/Library/Android/sdk/tools/android` program.
```

So we install that manually via `sdkmanager`.
