### PR TITLE
Update OxyPlot.Core to 2.2.0

### DIFF
--- a/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
+++ b/Source/OxyPlot.Maui.Skia/OxyPlot.Maui.Skia.csproj
@@ -34,7 +34,7 @@
 	  <CreatePackage>false</CreatePackage>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="OxyPlot.Core" Version="2.1.2" />
+		<PackageReference Include="OxyPlot.Core" Version="2.2.0" />
 		<PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.8" />
 		<PackageReference Include="SkiaSharp.Views.Maui.Controls" Version="2.88.8" />
 	</ItemGroup>

--- a/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
+++ b/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
@@ -64,7 +64,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="OxyPlot.ExampleLibrary" Version="2.1.2" />
+		<PackageReference Include="OxyPlot.ExampleLibrary" Version="2.2.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.70" />
 	</ItemGroup>
 


### PR DESCRIPTION
This updates OxyPlot.Core (and OxyPlot.ExampleLibrary) to the latest version 2.2.0. oxyplot-maui still builds well without any further changes, and also the samples look mostly fine (when skimming through them).

I also quickly looked through the release notes at https://github.com/oxyplot/oxyplot/releases/tag/v2.2.0, and it seems to me there aren't any breaking changes in this release. Is that right, @VisualMelon, or is there anything we should be aware of?