### PR TITLE
Update MauiOxyTouchEventArgs.cs

### DIFF
--- a/Source/OxyPlot.Maui.Skia/MauiOxyTouchEventArgs.cs
+++ b/Source/OxyPlot.Maui.Skia/MauiOxyTouchEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace OxyPlot.Maui.Skia;
 
-internal class MauiOxyTouchEventArgs : OxyTouchEventArgs
+public class MauiOxyTouchEventArgs : OxyTouchEventArgs
 {
     public int PointerCount { get; set; }
 


### PR DESCRIPTION
Change access modifier to match constructor

Allows access to public property when instance of this class is returned