### PR TITLE
Fix crash of sample app

### DIFF
--- a/Source/OxyPlot.Maui.Skia/Platforms/MacCatalyst/MauiFontLoader.cs
+++ b/Source/OxyPlot.Maui.Skia/Platforms/MacCatalyst/MauiFontLoader.cs
@@ -12,11 +12,11 @@ public class MauiFontLoader : IMauiFontLoader
         if (fontRegistrar == null)
             fontRegistrar = IPlatformApplication.Current.Services.GetRequiredService<IFontRegistrar>();
 
-        fontName = fontRegistrar.GetFont(fontName);
-        if (File.Exists(fontName))
-        {
+        fontName = fontRegistrar.GetFont(fontName) ?? fontName;
+        if (fontName == null)
+            return null;
+        else if (File.Exists(fontName))
             return File.OpenRead(fontName);
-        }
 
         try
         {

--- a/Source/OxyPlot.Maui.Skia/Platforms/iOS/MauiFontLoader.cs
+++ b/Source/OxyPlot.Maui.Skia/Platforms/iOS/MauiFontLoader.cs
@@ -13,10 +13,10 @@ public class MauiFontLoader : IMauiFontLoader
             fontRegistrar = IPlatformApplication.Current.Services.GetRequiredService<IFontRegistrar>();
 
         fontName = fontRegistrar.GetFont(fontName);
-        if (File.Exists(fontName))
-        {
+        if (fontName == null)
+            return null;
+        else if (File.Exists(fontName))
             return File.OpenRead(fontName);
-        }
 
         try
         {

--- a/Source/OxyPlot.Maui.Skia/Platforms/iOS/MauiFontLoader.cs
+++ b/Source/OxyPlot.Maui.Skia/Platforms/iOS/MauiFontLoader.cs
@@ -12,7 +12,7 @@ public class MauiFontLoader : IMauiFontLoader
         if (fontRegistrar == null)
             fontRegistrar = IPlatformApplication.Current.Services.GetRequiredService<IFontRegistrar>();
 
-        fontName = fontRegistrar.GetFont(fontName);
+        fontName = fontRegistrar.GetFont(fontName) ?? fontName;
         if (fontName == null)
             return null;
         else if (File.Exists(fontName))

--- a/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
+++ b/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
@@ -62,7 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="OxyPlot.ExampleLibrary" Version="2.2.0" />
-		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.40" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
+++ b/Source/OxyplotMauiSample/OxyplotMauiSample.csproj
@@ -13,10 +13,10 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<!-- Display name -->
-		<ApplicationTitle>OxyplotMauiSimple</ApplicationTitle>
+		<ApplicationTitle>OxyplotMauiSample</ApplicationTitle>
 
 		<!-- App Identifier -->
-		<ApplicationId>com.companyname.oxyplotmauisimple</ApplicationId>
+		<ApplicationId>com.companyname.oxyplotmauisample</ApplicationId>
 		<ApplicationIdGuid>2C1CD083-05E3-4080-840A-EC3B8334CCD7</ApplicationIdGuid>
 
 		<!-- Versions -->

--- a/Source/OxyplotMauiSample/Platforms/Tizen/tizen-manifest.xml
+++ b/Source/OxyplotMauiSample/Platforms/Tizen/tizen-manifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest package="maui-application-id-placeholder" version="0.0.0" api-version="7" xmlns="http://tizen.org/ns/packages">
   <profile name="common" />
-  <ui-application appid="maui-application-id-placeholder" exec="OxyplotMauiSimple.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
+  <ui-application appid="maui-application-id-placeholder" exec="OxyplotMauiSample.dll" multiple="false" nodisplay="false" taskmanage="true" type="dotnet" launch_mode="single">
     <label>maui-application-title-placeholder</label>
     <icon>maui-appicon-placeholder</icon>
     <metadata key="http://tizen.org/metadata/prefer_dotnet_aot" value="true" />

--- a/Source/OxyplotMauiSample/Platforms/Windows/app.manifest
+++ b/Source/OxyplotMauiSample/Platforms/Windows/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.0.0.0" name="OxyplotMauiSimple.WinUI.app"/>
+  <assemblyIdentity version="1.0.0.0" name="OxyplotMauiSample.WinUI.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>


### PR DESCRIPTION
This PR fixes a crash of the sample app, as reported in issue #26. The first commit contains the fix for the exception from #26, the second commit fixes a typo in the test app and the third commit updates MAUI to the latest version, in order to avoid crashes of the sample app with .NET 10.